### PR TITLE
Make use of extensible Base.Dates DateFormat

### DIFF
--- a/src/timezones/adjusters.jl
+++ b/src/timezones/adjusters.jl
@@ -12,10 +12,6 @@ end
 Base.trunc(dt::ZonedDateTime,::Type{Millisecond}) = dt
 
 # Adjusters
-
-# TODO: Should be included in Base.Dates.
-lastdayofyear(dt::DateTime) = DateTime(lastdayofyear(Date(dt)))
-
 for prefix in ("firstdayof", "lastdayof"), suffix in ("week", "month", "year", "quarter")
     func = symbol(prefix * suffix)
     @eval begin

--- a/src/timezones/io.jl
+++ b/src/timezones/io.jl
@@ -1,4 +1,4 @@
-import Base.Dates: Slot, AbstractTime, FixedWidthSlot, DelimitedSlot, DayOfWeekSlot, duplicates, getslot, periodisless
+import Base.Dates: DateFormat, Slot, slotrule, slotparse, slotformat
 
 Base.string(tz::TimeZone) = string(tz.name)
 Base.show(io::IO,tz::VariableTimeZone) = print(io,string(tz))
@@ -17,82 +17,25 @@ function Base.string(dt::ZonedDateTime)
 end
 Base.show(io::IO,dt::ZonedDateTime) = print(io,string(dt))
 
+# NOTE: The changes below require Base.Dates to be updated to include slotrule.
 
 # DateTime Parsing
+const ISOZonedDateTimeFormat = DateFormat("yyyy-mm-ddTHH:MM:SS.szzz")
 
-# Note: Ideally Base.Dates.Slot definition should just be: "abstract Slot{P<:Any}" which
-# would allow for custom Slots to be of any type.
-abstract TimeZoneSlot <: AbstractTime
+slotrule(::Type{Val{'z'}}) = TimeZone
+slotrule(::Type{Val{'Z'}}) = TimeZone
 
-function Base.Dates.slotparse(slot::Slot{TimeZoneSlot},x)
-    if slot.option == 1
+function slotparse(slot::Slot{TimeZone},x,locale)
+    if slot.letter == 'z'
         return ismatch(r"[\-\+\d\:]", x) ? FixedTimeZone(x): throw(SLOTERROR)
-    elseif slot.option == 2
+    elseif slot.letter == 'Z'
         # Note: TimeZones without the slash aren't well defined during parsing.
         return contains(x, "/") ? TimeZone(x) : throw(ArgumentError("Ambiguious timezone"))
     end
 end
 
-SLOT_TYPE = Dict(
-    'y' => Year,
-    'm' => Month,
-    'u' => Month,
-    'U' => Month,
-    'E' => DayOfWeekSlot,
-    'e' => DayOfWeekSlot,
-    'd' => Day,
-    'H' => Hour,
-    'M' => Minute,
-    'S' => Second,
-    's' => Millisecond,
-    'z' => TimeZoneSlot,
-    'Z' => TimeZoneSlot,
-)
+# TODO: Currently prints out the entire ZonedDateTime
+slotformat(slot::Slot{TimeZone},x,locale) = string(x)
 
-SLOT_OPTION = Dict(
-    'e' => 1,
-    'E' => 2,
-    'u' => 1,
-    'U' => 2,
-    'z' => 1,
-    'Z' => 2,
-)
-
-# Overwritten to allow for extensibility.
-function Base.Dates.DateFormat(f::AbstractString, locale::AbstractString="english")
-    slots = Slot[]
-    trans = []
-    ids = join(keys(SLOT_TYPE), "")
-    begtran, format = match(Regex("(^[^$ids]*)(.*)"), f).captures
-    s = split(format, Regex("[^$ids]+|(?<=([$ids])(?!\\1))"))
-    for (i,k) in enumerate(s)
-        k == "" && break
-        tran = i >= endof(s) ? r"$" : match(Regex("(?<=$(s[i])).*(?=$(s[i+1]))"),f).match
-        slot = tran == "" ? FixedWidthSlot : DelimitedSlot
-        width = length(k)
-        c = k[1]
-        typ = SLOT_TYPE[c]
-        option = get(SLOT_OPTION, c, 0)
-        push!(slots,slot(i,typ,width,option,locale))
-        push!(trans,tran)
-    end
-    duplicates(slots) && throw(ArgumentError("Two separate periods of the same type detected"))
-    return DateFormat(slots,begtran,trans)
-end
-
-# Overwritten to allow non-Period types to be returned.
-function Base.Dates.parse(x::AbstractString,df::DateFormat)
-    x = strip(replace(x, r"#.*$", ""))
-    x = replace(x,df.begtran,"")
-    isempty(x) && throw(ArgumentError("Cannot parse empty format string"))
-    (typeof(df.slots[1]) <: DelimitedSlot && first(search(x,df.trans[1])) == 0) && throw(ArgumentError("Delimiter mismatch. Couldn't find first delimiter, \"$(df.trans[1])\", in date string"))
-    periods = Period[]
-    extra = []
-    cursor = 1
-    for slot in df.slots
-        cursor, pe = getslot(x,slot,df,cursor)
-        pe != nothing && (isa(pe,Period) ? push!(periods,pe) : push!(extra,pe))
-        cursor > endof(x) && break
-    end
-    return vcat(sort!(periods,rev=true,lt=periodisless), extra)
-end
+ZonedDateTime(dt::AbstractString,df::DateFormat=ISOZonedDateTimeFormat) = ZonedDateTime(Base.Dates.parse(dt,df)...)
+ZonedDateTime(dt::AbstractString,format::AbstractString;locale::AbstractString="english") = ZonedDateTime(dt,DateFormat(format,locale))

--- a/src/timezones/io.jl
+++ b/src/timezones/io.jl
@@ -1,4 +1,4 @@
-import Base.Dates: DateFormat, Slot, slotrule, slotparse, slotformat
+import Base.Dates: DateFormat, Slot, slotparse, slotformat, SLOT_RULE
 
 Base.string(tz::TimeZone) = string(tz.name)
 Base.show(io::IO,tz::VariableTimeZone) = print(io,string(tz))
@@ -22,8 +22,8 @@ Base.show(io::IO,dt::ZonedDateTime) = print(io,string(dt))
 # DateTime Parsing
 const ISOZonedDateTimeFormat = DateFormat("yyyy-mm-ddTHH:MM:SS.szzz")
 
-slotrule(::Type{Val{'z'}}) = TimeZone
-slotrule(::Type{Val{'Z'}}) = TimeZone
+SLOT_RULE['z'] = TimeZone
+SLOT_RULE['Z'] = TimeZone
 
 function slotparse(slot::Slot{TimeZone},x,locale)
     if slot.letter == 'z'

--- a/src/timezones/types.jl
+++ b/src/timezones/types.jl
@@ -193,7 +193,7 @@ function ZonedDateTime(zdt::ZonedDateTime, tz::FixedTimeZone)
     return ZonedDateTime(zdt.utc_datetime, tz, tz)
 end
 
-function DateTime(parts::Union{Period,TimeZone}...)
+function ZonedDateTime(parts::Union{Period,TimeZone}...)
     periods = Period[]
     timezone = Nullable{TimeZone}()
     for part in parts
@@ -202,12 +202,12 @@ function DateTime(parts::Union{Period,TimeZone}...)
         elseif isnull(timezone)
             timezone = Nullable{TimeZone}(part)
         else
-            error("Multiple timezones found")
+            throw(ArgumentError("Multiple timezones found"))
         end
     end
 
-    dt = DateTime(periods...)
-    return isnull(timezone) ? dt : ZonedDateTime(dt, get(timezone))
+    isnull(timezone) && throw(ArgumentError("Missing timezone"))
+    return ZonedDateTime(DateTime(periods...), get(timezone))
 end
 
 # Equality

--- a/test/timezones/io.jl
+++ b/test/timezones/io.jl
@@ -18,9 +18,12 @@ show(buffer, ZonedDateTime(dt, warsaw))
 @test takebuf_string(buffer) == "1942-12-25T01:23:45+01:00"
 
 # ZonedDateTime parsing
-@test DateTime("1942-12-25T01:23:45+0100", "yyyy-mm-ddTHH:MM:SSzzz") == ZonedDateTime(dt, fixed)
-@test DateTime("1942-12-25T01:23:45 Europe/Warsaw", "yyyy-mm-ddTHH:MM:SS ZZZ") == ZonedDateTime(dt, warsaw)
+@test ZonedDateTime("1942-12-25T01:23:45+0100", "yyyy-mm-ddTHH:MM:SSzzz") == ZonedDateTime(dt, fixed)
+@test ZonedDateTime("1942-12-25T01:23:45 Europe/Warsaw", "yyyy-mm-ddTHH:MM:SS ZZZ") == ZonedDateTime(dt, warsaw)
 
 # Note: CET here represents the FixedTimeZone used in Europe/Warsaw and not the
 # VariableTimeZone CET.
-@test_throws ArgumentError DateTime("1942-12-25T01:23:45 CET", "yyyy-mm-ddTHH:MM:SS ZZZ")
+@test_throws ArgumentError ZonedDateTime("1942-12-25T01:23:45 CET", "yyyy-mm-ddTHH:MM:SS ZZZ")
+
+# Creating a ZonedDateTime requires a TimeZone to be present.
+@test_throws ArgumentError ZonedDateTime("1942-12-25T01:23:45", "yyyy-mm-ddTHH:MM:SSzzz")

--- a/test/timezones/types.jl
+++ b/test/timezones/types.jl
@@ -272,5 +272,5 @@ fall_apia = ZonedDateTime(DateTime(2010, 10, 1, 2), apia)
 @test_throws NonExistentTimeError ZonedDateTime(early_utc, apia)
 
 
-# DateTime constructor that takes any number of Period or TimeZone types
-@test_throws Exception DateTime(FixedTimeZone("UTC", 0, 0), FixedTimeZone("TMW", 86400, 0))
+# ZonedDateTime constructor that takes any number of Period or TimeZone types
+@test_throws ArgumentError ZonedDateTime(FixedTimeZone("UTC", 0, 0), FixedTimeZone("TMW", 86400, 0))


### PR DESCRIPTION
The following changes require that https://github.com/JuliaLang/julia/pull/12799 be merged into base Julia first. These changes make use of an extensible version of DateFormat which allows us to remove the overwritten methods.