### PR TITLE
Initial transition effective from typemin(DateTime)

### DIFF
--- a/src/timezones/Olson.jl
+++ b/src/timezones/Olson.jl
@@ -45,12 +45,9 @@ typealias ZoneDict Dict{AbstractString,Array{Zone}}
 typealias RuleDict Dict{AbstractString,Array{Rule}}
 typealias OrderedRuleDict Dict{AbstractString,Tuple{Array{Date},Array{Rule}}}
 
-# Min and max years that we create DST transition instants for (inclusive)
-const MINYEAR = 1800
-const MAXYEAR = 2038
-
-const MINDATETIME = DateTime(MINYEAR,1,1)
-const MAXDATETIME = DateTime(MAXYEAR,12,31)
+# Min and max DateTimes that we create DST transition instants for (inclusive)
+const MINDATETIME = typemin(DateTime)
+const MAXDATETIME = DateTime(2038,12,31)
 
 # Helper functions/data
 const MONTHS = Dict("Jan"=>1,"Feb"=>2,"Mar"=>3,"Apr"=>4,"May"=>5,"Jun"=>6,
@@ -253,7 +250,7 @@ function order_rules(rules::Array{Rule})
     # Note: Typically rules are orderd by "from" and "in". Unfortunately
     for rule in rules
         # Replicate the rule for each year that it is effective.
-        for rule_year in get(rule.from, MINYEAR):get(rule.to, MAXYEAR)
+        for rule_year in get(rule.from, year(MINDATETIME)):get(rule.to, year(MAXDATETIME))
             # Determine the rule transition day by starting at the
             # beginning of the month and applying our "on" function
             # until we reach the correct day.

--- a/test/timezones/Olson.jl
+++ b/test/timezones/Olson.jl
@@ -66,7 +66,7 @@ zone["CEST"] = FixedTimeZone("CEST", 3600, 3600)
 zone["EET"] = FixedTimeZone("EET", 7200, 0)
 zone["EEST"] = FixedTimeZone("EEST", 7200, 3600)
 
-@test warsaw.transitions[1] == Transition(DateTime(1800,1,1), zone["LMT"])  # Really should be -Inf
+@test warsaw.transitions[1] == Transition(typemin(DateTime), zone["LMT"])  # Ideally -Inf
 @test warsaw.transitions[2] == Transition(DateTime(1879,12,31,22,36), zone["WMT"])
 @test warsaw.transitions[3] == Transition(DateTime(1915,8,4,22,36), zone["CET"])
 @test warsaw.transitions[4] == Transition(DateTime(1916,4,30,22,0), zone["CEST"])
@@ -99,7 +99,7 @@ zone["HST"] = FixedTimeZone("HST", -37800, 0)
 zone["HDT"] = FixedTimeZone("HDT", -37800, 3600)
 zone["HST_NEW"] = FixedTimeZone("HST", -36000, 0)
 
-@test honolulu.transitions[1] == Transition(DateTime(1800,1,1), zone["LMT"])
+@test honolulu.transitions[1] == Transition(typemin(DateTime), zone["LMT"])
 @test honolulu.transitions[2] == Transition(DateTime(1896,1,13,22,31,26), zone["HST"])
 @test honolulu.transitions[3] == Transition(DateTime(1933,4,30,12,30), zone["HDT"])
 @test honolulu.transitions[4] == Transition(DateTime(1933,5,21,21,30), zone["HST"])
@@ -127,7 +127,7 @@ zone["SDT"] = FixedTimeZone("SDT", -39600, 3600)
 zone["WSST"] = FixedTimeZone("WSST", 46800, 0)
 zone["WSDT"] = FixedTimeZone("WSDT", 46800, 3600)
 
-@test apia.transitions[1] == Transition(DateTime(1800,1,1), zone["LMT_OLD"])
+@test apia.transitions[1] == Transition(typemin(DateTime), zone["LMT_OLD"])
 @test apia.transitions[2] == Transition(DateTime(1879,7,4,11,26,56), zone["LMT"])
 @test apia.transitions[3] == Transition(DateTime(1911,1,1,11,26,56), zone["WSST_OLD"])
 @test apia.transitions[4] == Transition(DateTime(1950,1,1,11,30), zone["SST"])
@@ -197,7 +197,7 @@ zone["TDT-4"] = FixedTimeZone("TDT-4", -36000, 3600)
 zone["TST-5"] = FixedTimeZone("TST-5", -36000, 0)
 zone["TDT-5"] = FixedTimeZone("TDT-5", -36000, 3600)
 
-@test test.transitions[1] == Transition(DateTime(1800,1,1), zone["TST-1"])
+@test test.transitions[1] == Transition(typemin(DateTime), zone["TST-1"])
 @test test.transitions[2] == Transition(DateTime(1933,4,1,12), zone["TDT-2"]) # -09:00
 @test test.transitions[3] == Transition(DateTime(1933,9,1,12), zone["TST-3"])
 @test test.transitions[4] == Transition(DateTime(1934,4,1,13), zone["TDT-3"])

--- a/test/timezones/types.jl
+++ b/test/timezones/types.jl
@@ -1,5 +1,5 @@
 import TimeZones: Transition
-import Base.Dates: Second
+import Base.Dates: Second, UTM
 
 
 # Constructor FixedTimeZone from a string.
@@ -246,7 +246,9 @@ utc = FixedTimeZone("UTC", 0, 0)
 
 spring_utc = ZonedDateTime(DateTime(2010, 5, 1, 12), utc)
 spring_apia = ZonedDateTime(DateTime(2010, 5, 1, 1), apia)
-early_utc = ZonedDateTime(DateTime(1, 1, 1, 0), utc)
+
+# The absolutely min DateTime you can create. Even smaller than typemin(DateTime)
+early_utc = ZonedDateTime(DateTime(UTM(typemin(Int64))), utc)
 
 @test spring_utc.zone == FixedTimeZone("UTC", 0, 0)
 @test spring_apia.zone == FixedTimeZone("SST", -39600, 0)

--- a/test/timezones/tzfile.jl
+++ b/test/timezones/tzfile.jl
@@ -6,8 +6,7 @@ function overlap(a::Array{Transition}, b::Array{Transition})
     start_dt = max(first(a).utc_datetime, first(b).utc_datetime)
     end_dt = min(last(a).utc_datetime, last(b).utc_datetime)
 
-    # Start may not be equal as the initial transition date is arbitrary
-    within = t -> start_dt < t.utc_datetime <= end_dt
+    within = t -> start_dt <= t.utc_datetime <= end_dt
     return a[find(within, a)], b[find(within, b)]
 end
 
@@ -47,7 +46,9 @@ open(joinpath(TZFILE_DIR, "Europe", "Warsaw (Version 2)")) do f
     @test string(tz) == "Europe/Warsaw"
     @test first(tz.transitions).utc_datetime == typemin(DateTime)
     @test last(tz.transitions).utc_datetime == DateTime(2037,10,25,1)
-    @test ==(overlap(tz.transitions, warsaw.transitions[2:end])...)
+
+    # File skips 1879-12-31T22:36:00
+    @test ==(overlap(tz.transitions, warsaw.transitions[3:end])...)
 end
 
 # Read version 2 data


### PR DESCRIPTION
VariableTimeZone types are made up of transitions which have a UTC DateTime indicating the instant at when the new rule becomes effective. Previously the first transition started at 1800/1/1 for no real reason except that no zone or rule started that early and it is rather silly to use the concept of time zones prior to their use. After merging in #8 it seems more reasonable to allow users to make ZonedDateTime's prior to 1800 and let them use their own judgement.

As a happy side effect this makes comparing Julia processed timezone rules easier to compare with tzfiles.