### PR TITLE
Add support for local system TimeZone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 # Ignore dependencies that are build/retrieved
 deps/tzdata
 deps/compiled
+deps/windows

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@
 # Ignore dependencies that are build/retrieved
 deps/tzdata
 deps/compiled
-deps/windows

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.4-
+@windows LightXML

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,4 @@
 julia 0.4-
+
+# Only required for building
 @windows LightXML

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,7 +1,7 @@
 import TimeZones: TZDATA_DIR, COMPILED_DIR
 import TimeZones.Olson: compile
 
-@windows_only import TimeZones: TRANSLATION_FILE
+@windows_only import TimeZones: WIN_TRANSLATION_FILE
 @windows_only using LightXML
 
 # See "ftp://ftp.iana.org/tz/data/Makefile" PRIMARY_YDATA for listing of
@@ -54,16 +54,17 @@ end
 compile(TZDATA_DIR, COMPILED_DIR)
 
 @windows_only begin
-    translation_dir = dirname(TRANSLATION_FILE)
+    translation_dir = dirname(WIN_TRANSLATION_FILE)
     isdir(translation_dir) || mkdir(translation_dir)
 
     # Windows is weird and uses its own timezone
-    info("Downloading Windows to TZ name XML")
+    info("Downloading Windows to POSIX timezone name XML")
 
     # Generate the mapping between MS Windows timezone names and
     # tzdata/Olsen timezone names, by retrieving a file.
     xml_source = "http://unicode.org/cldr/data/common/supplemental/windowsZones.xml"
     xml_file = joinpath(translation_dir, "windowsZones.xml")
+
     # Download the xml file from source
     download(xml_source, xml_file)
 
@@ -92,7 +93,7 @@ compile(TZDATA_DIR, COMPILED_DIR)
     end
 
     # Save the dictionary
-    open(TRANSLATION_FILE, "w") do fp
+    open(WIN_TRANSLATION_FILE, "w") do fp
         serialize(fp, win_tz)
     end
 end

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,6 +1,9 @@
 import TimeZones: TZDATA_DIR, COMPILED_DIR
 import TimeZones.Olson: compile
 
+@windows_only import TimeZones: TRANSLATION_FILE
+@windows_only using LightXML
+
 # See "ftp://ftp.iana.org/tz/data/Makefile" PRIMARY_YDATA for listing of
 # regions to include. YDATA includes historical zones which we'll ignore.
 const REGIONS = (
@@ -49,5 +52,49 @@ for file in readdir(COMPILED_DIR)
     rm(joinpath(COMPILED_DIR, file), recursive=true)
 end
 compile(TZDATA_DIR, COMPILED_DIR)
+
+@windows_only begin
+    translation_dir = dirname(TRANSLATION_FILE)
+    isdir(translation_dir) || mkdir(translation_dir)
+
+    # Windows is weird and uses its own timezone
+    info("Downloading Windows to TZ name XML")
+
+    # Generate the mapping between MS Windows timezone names and
+    # tzdata/Olsen timezone names, by retrieving a file.
+    xml_source = "http://unicode.org/cldr/data/common/supplemental/windowsZones.xml"
+    xml_file = joinpath(translation_dir, "windowsZones.xml")
+    # Download the xml file from source
+    download(xml_source, xml_file)
+
+    info("Pre-processing Windows translation")
+
+    # Get the timezone conversions from the file
+    xdoc = parse_file(xml_file)
+    xroot = root(xdoc)
+    windowsZones = find_element(xroot, "windowsZones")
+    mapTimezones = find_element(windowsZones, "mapTimezones")
+    # Every mapZone is a conversion
+    mapZones = get_elements_by_tagname(mapTimezones, "mapZone")
+
+    # Dictionary to store the windows to timezone conversions
+    win_tz = Dict{AbstractString,AbstractString}()
+
+    # Add conversions to the dictionary
+    for mapzone in mapZones
+        # territory "001" is the global default
+        # http://cldr.unicode.org/development/development-process/design-proposals/extended-windows-olson-zid-mapping
+        if attribute(mapzone, "territory") == "001"
+            windowszone = attribute(mapzone, "other")
+            utczone = attribute(mapzone, "type")
+            win_tz[windowszone] = utczone
+        end
+    end
+
+    # Save the dictionary
+    open(TRANSLATION_FILE, "w") do fp
+        serialize(fp, win_tz)
+    end
+end
 
 info("Successfully processed TimeZone data")

--- a/src/TimeZones.jl
+++ b/src/TimeZones.jl
@@ -17,7 +17,7 @@ export TimeZone, FixedTimeZone, VariableTimeZone, ZonedDateTime,
     # conversion.jl
     now,
     # local.jl
-    get_localzone
+    localzone
 
 const PKG_DIR = normpath(joinpath(dirname(@__FILE__), "..", "deps"))
 const TZDATA_DIR = joinpath(PKG_DIR, "tzdata")

--- a/src/TimeZones.jl
+++ b/src/TimeZones.jl
@@ -15,7 +15,9 @@ export TimeZone, FixedTimeZone, VariableTimeZone, ZonedDateTime,
     # Re-export from Base.Dates
     yearmonthday, yearmonth, monthday, year, month, week, day, dayofmonth,
     # conversion.jl
-    now
+    now,
+    # local.jl
+    get_localzone
 
 const PKG_DIR = normpath(joinpath(dirname(@__FILE__), "..", "deps"))
 const TZDATA_DIR = joinpath(PKG_DIR, "tzdata")
@@ -30,6 +32,7 @@ include("timezones/tzfile.jl")
 include("timezones/adjusters.jl")
 include("timezones/Olson.jl")
 include("timezones/conversions.jl")
+include("timezones/local.jl")
 
 function TimeZone(name::AbstractString)
     tz_path = joinpath(COMPILED_DIR, split(name, "/")...)

--- a/src/TimeZones.jl
+++ b/src/TimeZones.jl
@@ -19,10 +19,10 @@ export TimeZone, FixedTimeZone, VariableTimeZone, ZonedDateTime,
     # local.jl
     localzone
 
-const PKG_DIR = normpath(joinpath(dirname(@__FILE__), "..", "deps"))
-const TZDATA_DIR = joinpath(PKG_DIR, "tzdata")
-const COMPILED_DIR = joinpath(PKG_DIR, "compiled")
-@windows_only const TRANSLATION_FILE = joinpath(PKG_DIR, "windows_translation")
+const PKG_DIR = normpath(joinpath(dirname(@__FILE__), ".."))
+const TZDATA_DIR = joinpath(PKG_DIR, "deps", "tzdata")
+const COMPILED_DIR = joinpath(PKG_DIR, "deps", "compiled")
+@windows_only const TRANSLATION_FILE = joinpath(PKG_DIR, "deps", "windows_translation")
 
 include("timezones/time.jl")
 include("timezones/types.jl")

--- a/src/TimeZones.jl
+++ b/src/TimeZones.jl
@@ -22,7 +22,10 @@ export TimeZone, FixedTimeZone, VariableTimeZone, ZonedDateTime,
 const PKG_DIR = normpath(joinpath(dirname(@__FILE__), ".."))
 const TZDATA_DIR = joinpath(PKG_DIR, "deps", "tzdata")
 const COMPILED_DIR = joinpath(PKG_DIR, "deps", "compiled")
-@windows_only const TRANSLATION_FILE = joinpath(PKG_DIR, "deps", "windows_translation")
+
+@windows_only begin
+    const WIN_TRANSLATION_FILE = joinpath(PKG_DIR, "deps", "windows_translation.xml")
+end
 
 include("timezones/time.jl")
 include("timezones/types.jl")

--- a/src/TimeZones.jl
+++ b/src/TimeZones.jl
@@ -22,6 +22,7 @@ export TimeZone, FixedTimeZone, VariableTimeZone, ZonedDateTime,
 const PKG_DIR = normpath(joinpath(dirname(@__FILE__), "..", "deps"))
 const TZDATA_DIR = joinpath(PKG_DIR, "tzdata")
 const COMPILED_DIR = joinpath(PKG_DIR, "compiled")
+@windows_only const TRANSLATION_FILE = joinpath(PKG_DIR, "windows_translation")
 
 include("timezones/time.jl")
 include("timezones/types.jl")

--- a/src/timezones/local.jl
+++ b/src/timezones/local.jl
@@ -1,0 +1,101 @@
+# Determine the local systems timezone
+# Based upon Python's tzlocal https://pypi.python.org/pypi/tzlocal
+
+function get_localzone()
+    @osx? _get_localzone_mac():(
+        @unix? _get_localzone_unix():(
+            # TODO Add support for Windows
+            error("Failed to find local timezone (Windows is not currently supported)")
+        )
+    )
+end
+
+function _get_localzone_mac()
+    zone = readall(`systemsetup -gettimezone`)
+    if contains(zone, "Time Zone: ")
+        zone = strip(replace(zone, "Time Zone: ", ""))
+    else
+        zone = readlink("/etc/localtime")
+        # link will be something like /usr/share/zoneinfo/America/Winnipeg
+        zone = match(r"(?<=zoneinfo/).*$", zone).match
+    end
+    return zone
+end
+
+function _get_localzone_unix()
+    validnames = timezone_names()
+
+    # Try getting the time zone "TZ" environment variable
+    # http://linux.die.net/man/3/tzset
+    zone = Nullable{AbstractString}(get(ENV, "TZ", nothing))
+    if !isnull(zone)
+        zone_str = get(zone)
+        if startswith(zone_str,':')
+            zone_str = zone_str[2:end]
+        end
+        zone_str in validnames && return zone_str
+
+        # TODO Read the tzfile to get the timezone
+
+        error("Failed to resolve local timezone from \"TZ\" environment variable. ",
+            "Only currently support timezone names as the \"TZ\" environment variable")
+    end
+
+    # Look for distribution specific configuration files
+    # that contain the timezone name.
+
+    filename = "/etc/timezone"
+    if isfile(filename)
+        zone = ""
+        open(filename) do file
+            zone = readall(file)
+            # Get rid of host definitions and comments:
+            zone = strip(replace(zone, r"#.*", ""))
+            zone = replace(zone, ' ', '_')
+        end
+        zone in validnames && return zone
+    end
+
+    # CentOS has a ZONE setting in /etc/sysconfig/clock,
+    # OpenSUSE has a TIMEZONE setting in /etc/sysconfig/clock and
+    # Gentoo has a TIMEZONE setting in /etc/conf.d/clock
+
+    zone_re = r"(?:TIME)?ZONE\s*=\s*\"(.*?)\""
+    for filename in ("/etc/sysconfig/clock", "/etc/conf.d/clock")
+        isfile(filename) || continue
+        file = open(filename)
+        try # Make sure we close the file
+            for line in readlines(file)
+                matched = match(zone_re, line)
+                if matched != nothing
+                    zone = matched.captures[1]
+                    zone = replace(zone, ' ', '_')
+
+                    zone in validnames && return zone
+                end
+            end
+        finally
+            close(file)
+        end
+    end
+
+    # systemd distributions use symlinks that include the zone name,
+    # see manpage of localtime(5) and timedatectl(1)
+    link = "/etc/localtime"
+    if islink(link)
+        zone = readlink(link)
+        start = search(zone, '/')
+
+        while start != 0
+            zone = zone[(start+1):end]
+
+            zone in validnames && return zone
+
+            start = search(zone, '/')
+        end
+    end
+
+    # TODO No explicit setting existed. Use localtime
+
+    error("Failed to find local timezone")
+end

--- a/src/timezones/local.jl
+++ b/src/timezones/local.jl
@@ -2,111 +2,126 @@
 # Based upon Python's tzlocal https://pypi.python.org/pypi/tzlocal
 
 @osx_only function localzone()
-    zone = readall(`systemsetup -gettimezone`)
-    if contains(zone, "Time Zone: ")
-        zone = strip(replace(zone, "Time Zone: ", ""))
+    name = readall(`systemsetup -gettimezone`)
+    if contains(name, "Time Zone: ")
+        name = strip(replace(name, "Time Zone: ", ""))
     else
-        zone = readlink("/etc/localtime")
-        # link will be something like /usr/share/zoneinfo/America/Winnipeg
-        zone = match(r"(?<=zoneinfo/).*$", zone).match
+        # link will be something like /usr/share/zoneinfo/Europe/Warsaw
+        name = readlink("/etc/localtime")
+        name = match(r"(?<=zoneinfo/).*$", name).match
     end
-    return zone
+    return TimeZone(name)
 end
 
 @linux_only function localzone()
+    name = ""
     validnames = timezone_names()
 
-    # Try getting the time zone "TZ" environment variable
+    # Try getting the time zone from the "TZ" environment variable
     # http://linux.die.net/man/3/tzset
-    zone = Nullable{AbstractString}(get(ENV, "TZ", nothing))
-    if !isnull(zone)
-        zone_str = get(zone)
-        if startswith(zone_str,':')
-            zone_str = zone_str[2:end]
+    if haskey(ENV, "TZ")
+        name = ENV["TZ"]
+        startswith(name, ':') || error("Currently only support filespec for TZ variable")
+        name = name[2:end]
+
+        if startswith(name, '/')
+            return open(name) do f
+                read_tzfile(f, "local")
+            end
+        else
+            # Relative name matches pre-compiled timezone name
+            name in validnames && return TimeZone(name)
+
+            # The system timezone directory used depends on the (g)libc version
+            tzdirs = ["/usr/lib/zoneinfo", "/usr/share/zoneinfo"]
+            haskey(ENV, "TZDIR") && unshift!(tzdirs, ENV["TZDIR"])
+
+            for dir in tzdirs
+                filepath = joinpath(dir, name)
+                isfile(filepath) || continue
+                return open(filepath) do f
+                    read_tzfile(f, name)
+                end
+            end
+
+            throw(SystemError("unable to locate tzfile: $name"))
         end
-        zone_str in validnames && return zone_str
-
-        # TODO Read the tzfile to get the timezone
-
-        error("Failed to resolve local timezone from \"TZ\" environment variable. ",
-            "Only currently support timezone names as the \"TZ\" environment variable")
     end
 
-    # Look for distribution specific configuration files
-    # that contain the timezone name.
+    # Look for distribution specific configuration files that contain the timezone name.
 
     filename = "/etc/timezone"
     if isfile(filename)
-        zone = ""
         open(filename) do file
-            zone = readall(file)
+            name = readall(file)
+
             # Get rid of host definitions and comments:
-            zone = strip(replace(zone, r"#.*", ""))
-            zone = replace(zone, ' ', '_')
+            name = strip(replace(name, r"#.*", ""))
+            name = replace(name, ' ', '_')
         end
-        zone in validnames && return zone
+
+        name in validnames && return TimeZone(name)
     end
 
     # CentOS has a ZONE setting in /etc/sysconfig/clock,
     # OpenSUSE has a TIMEZONE setting in /etc/sysconfig/clock and
     # Gentoo has a TIMEZONE setting in /etc/conf.d/clock
 
-    zone_re = r"(?:TIME)?ZONE\s*=\s*\"(.*?)\""
-    for filename in ("/etc/sysconfig/clock", "/etc/conf.d/clock")
-        isfile(filename) || continue
-        file = open(filename)
-        try # Make sure we close the file
+    zone_re = r"(TIME)?ZONE\s*=\s*\"(?<name>.*?)\""
+    for filepath in ("/etc/sysconfig/clock", "/etc/conf.d/clock")
+        isfile(filepath) || continue
+        open(filepath) do file
             for line in readlines(file)
                 matched = match(zone_re, line)
                 if matched != nothing
-                    zone = matched.captures[1]
-                    zone = replace(zone, ' ', '_')
-
-                    zone in validnames && return zone
+                    name = matched.captures["name"]
+                    name = replace(name, ' ', '_')
+                    break
                 end
             end
-        finally
-            close(file)
         end
+
+        name in validnames && return TimeZone(name)
     end
 
     # systemd distributions use symlinks that include the zone name,
     # see manpage of localtime(5) and timedatectl(1)
     link = "/etc/localtime"
     if islink(link)
-        zone = readlink(link)
-        start = search(zone, '/')
+        filepath = readlink(link)
+        start = search(filepath, '/')
 
         while start != 0
-            zone = zone[(start+1):end]
-
-            zone in validnames && return zone
-
-            start = search(zone, '/')
+            name = filepath[(start + 1):end]
+            name in validnames && return TimeZone(name)
+            start = search(filepath, '/', start + 1)
         end
     end
 
-    # TODO No explicit setting existed. Use localtime
+    # No explicit setting existed. Use localtime
+    for filepath in ("/etc/localtime", "/usr/local/etc/localtime")
+        isfile(filepath) || continue
+        return open(filepath) do f
+            read_tzfile(f, "local")
+        end
+    end
 
     error("Failed to find local timezone")
 end
 
 @windows_only function localzone()
-    isfile(TRANSLATION_FILE) ||
-        error("Windows zones not found. Try running Pkg.build(\"TimeZones\")")
+    isfile(TRANSLATION_FILE) || error("Missing Windows to POSIX timezone translation ",
+        "file. Try running Pkg.build(\"TimeZones\")")
 
-    win_tz_dict = nothing
-    open(TRANSLATION_FILE, "r") do fp
-        win_tz_dict = deserialize(fp)
+    translation = open(TRANSLATION_FILE, "r") do fp
+        deserialize(fp)
     end
 
+    # Windows powershell should be available on Windows 7 and above
     winzone = strip(readall(`powershell -Command "[TimeZoneInfo]::Local.Id"`))
-    if haskey(win_tz_dict, winzone)
-        timezone = win_tz_dict[winzone]
+    if haskey(translation, winzone)
+        return TimeZone(translation[winzone])
     else
-        error("Failed to determine your Windows timezone. ",
-            "Uses powershell, should work on windows 7 and above")
+        error("unable to translate to POSIX timezone name: $winzone")
     end
-
-    return timezone
 end

--- a/src/timezones/local.jl
+++ b/src/timezones/local.jl
@@ -2,10 +2,9 @@
 # Based upon Python's tzlocal https://pypi.python.org/pypi/tzlocal
 
 function get_localzone()
-    @osx? _get_localzone_mac():(
-        @unix? _get_localzone_unix():(
-            # TODO Add support for Windows
-            error("Failed to find local timezone (Windows is not currently supported)")
+    @windows? _get_localzone_windows():(
+        @osx? _get_localzone_mac():(
+            _get_localzone_unix()
         )
     )
 end
@@ -98,4 +97,24 @@ function _get_localzone_unix()
     # TODO No explicit setting existed. Use localtime
 
     error("Failed to find local timezone")
+end
+
+function _get_localzone_windows()
+    isfile(TRANSLATION_FILE) ||
+        error("Windows zones not found. Try running Pkg.build(\"TimeZones\")")
+
+    win_tz_dict = nothing
+    open(TRANSLATION_FILE, "r") do fp
+        win_tz_dict = deserialize(fp)
+    end
+
+    winzone = strip(readall(`powershell -Command "[TimeZoneInfo]::Local.Id"`))
+    if haskey(win_tz_dict, winzone)
+        timezone = win_tz_dict[winzone]
+    else
+        error("Failed to determine your Windows timezone. ",
+            "Uses powershell, should work on windows 7 and above")
+    end
+
+    return timezone
 end

--- a/src/timezones/local.jl
+++ b/src/timezones/local.jl
@@ -1,15 +1,7 @@
 # Determine the local systems timezone
 # Based upon Python's tzlocal https://pypi.python.org/pypi/tzlocal
 
-function get_localzone()
-    @windows? _get_localzone_windows():(
-        @osx? _get_localzone_mac():(
-            _get_localzone_unix()
-        )
-    )
-end
-
-function _get_localzone_mac()
+@osx_only function localzone()
     zone = readall(`systemsetup -gettimezone`)
     if contains(zone, "Time Zone: ")
         zone = strip(replace(zone, "Time Zone: ", ""))
@@ -21,7 +13,7 @@ function _get_localzone_mac()
     return zone
 end
 
-function _get_localzone_unix()
+@linux_only function localzone()
     validnames = timezone_names()
 
     # Try getting the time zone "TZ" environment variable
@@ -99,7 +91,7 @@ function _get_localzone_unix()
     error("Failed to find local timezone")
 end
 
-function _get_localzone_windows()
+@windows_only function localzone()
     isfile(TRANSLATION_FILE) ||
         error("Windows zones not found. Try running Pkg.build(\"TimeZones\")")
 

--- a/src/timezones/local.jl
+++ b/src/timezones/local.jl
@@ -2,7 +2,7 @@
 # Based upon Python's tzlocal https://pypi.python.org/pypi/tzlocal
 
 @osx_only function localzone()
-    name = readall(`systemsetup -gettimezone`)
+    name = readall(`systemsetup -gettimezone`)  # Appears to only work as root
     if contains(name, "Time Zone: ")
         name = strip(replace(name, "Time Zone: ", ""))
     else
@@ -74,7 +74,7 @@ end
             for line in readlines(file)
                 matched = match(zone_re, line)
                 if matched != nothing
-                    name = matched.captures["name"]
+                    name = matched["name"]
                     name = replace(name, ' ', '_')
                     break
                 end

--- a/src/timezones/local.jl
+++ b/src/timezones/local.jl
@@ -110,10 +110,10 @@ end
 end
 
 @windows_only function localzone()
-    isfile(TRANSLATION_FILE) || error("Missing Windows to POSIX timezone translation ",
+    isfile(WIN_TRANSLATION_FILE) || error("Missing Windows to POSIX timezone translation ",
         "file. Try running Pkg.build(\"TimeZones\")")
 
-    translation = open(TRANSLATION_FILE, "r") do fp
+    translation = open(WIN_TRANSLATION_FILE, "r") do fp
         deserialize(fp)
     end
 

--- a/src/timezones/types.jl
+++ b/src/timezones/types.jl
@@ -46,13 +46,29 @@ function FixedTimeZone(name::AbstractString, utc_offset::Integer, dst_offset::In
 end
 
 function FixedTimeZone(s::AbstractString)
-    m = match(r"^([+-]?\d{2})\:?(\d{2})(?:\:(\d{2}+))?$", s)
+    const regex = r"""
+    ^(?|
+        UTC([+-]\d{1,2})?
+        |
+        (?:UTC(?=[+-]))?
+        ([+-]?\d{2})
+        (?|
+            (\d{2})
+            |
+            \:(\d{2})
+            (?:\:(\d{2}))?
+        )
+    )$
+    """x
+
+    m = match(regex, s)
     m == nothing && error("Unrecognized timezone: $s")
 
-    # TODO: Somehow this is not working in the package but works in the REPL
     values = map(n -> n == nothing ? 0 : Base.parse(Int, n), m.captures)
 
-    if values[3] == 0
+    if values == [0, 0, 0]
+        name = "UTC"
+    elseif values[3] == 0
         name = @sprintf("UTC%+03d:%02d", values[1:2]...)
     else
         name = @sprintf("UTC%+03d:%02d:%02d", values...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,10 @@
 using TimeZones
 using Base.Test
 
-import TimeZones: TZDATA_DIR
+import TimeZones: PKG_DIR, TZDATA_DIR
 import TimeZones.Olson: ZoneDict, RuleDict, tzparse, resolve
 
-const TEST_DIR = normpath(dirname(@__FILE__))
-const TZFILE_DIR = joinpath(TEST_DIR, "tzfile")
+const TZFILE_DIR = joinpath(PKG_DIR, "test", "tzfile")
 
 # For testing we'll reparse the tzdata every time to instead of using the serialized data.
 # This should make the development/testing cycle simplier since you won't be forced to

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,8 @@ using Base.Test
 import TimeZones: TZDATA_DIR
 import TimeZones.Olson: ZoneDict, RuleDict, tzparse, resolve
 
-const TZFILE_DIR = normpath(joinpath(dirname(@__FILE__), "tzfile"))
+const TEST_DIR = normpath(dirname(@__FILE__))
+const TZFILE_DIR = joinpath(TEST_DIR, "tzfile")
 
 # For testing we'll reparse the tzdata every time to instead of using the serialized data.
 # This should make the development/testing cycle simplier since you won't be forced to
@@ -26,4 +27,5 @@ include("timezones/io.jl")
 include("timezones/tzfile.jl")
 include("timezones/adjusters.jl")
 include("timezones/conversions.jl")
+include("timezones/local.jl")
 include("timezone_names.jl")

--- a/test/timezones/local.jl
+++ b/test/timezones/local.jl
@@ -1,0 +1,51 @@
+# Make sure that the current systems local timezone is supported.
+@test isa(localzone(), TimeZone)
+
+@linux_only begin
+    # Bad TZ environmental variables
+    withenv("TZ" => "") do
+        @test_throws ErrorException localzone()
+    end
+    withenv("TZ" => "Europe/Warsaw") do
+        @test_throws ErrorException localzone()
+    end
+
+    # Absolute filespec
+    warsaw_path = joinpath(TZFILE_DIR, "Europe", "Warsaw")
+    warsaw_from_file = open(warsaw_path) do f
+        TimeZones.read_tzfile(f, "local")
+    end
+    withenv("TZ" => ":" * abspath(warsaw_path)) do
+        @test localzone() == warsaw_from_file
+    end
+
+    # Relative filespec
+    warsaw = TimeZone("Europe/Warsaw")
+    withenv("TZ" => ":Europe/Warsaw") do
+        @test localzone() == warsaw
+    end
+
+    # Set TZDIR and use timezone unrecognized by TimeZone
+    @test_throws ErrorException TimeZone("Etc/UTC")
+    utc = open(joinpath(TZFILE_DIR, "Etc", "UTC")) do f
+        TimeZones.read_tzfile(f, "Etc/UTC")
+    end
+    withenv("TZ" => ":Etc/UTC", "TZDIR" => TZFILE_DIR) do
+        @test localzone() == utc
+    end
+
+    # Use system installed files
+    @test_throws ErrorException TimeZone("Etc/GMT-9")
+    gmt_minus_9 = FixedTimeZone("GMT-9", 9 * 3600)
+    withenv("TZ" => ":Etc/GMT-9") do
+        @test localzone() == gmt_minus_9
+    end
+
+    # Unable to locate timezone on system
+    withenv("TZ" => ":") do
+        @test_throws SystemError localzone()
+    end
+    withenv("TZ" => ":Etc/Foo") do
+        @test_throws SystemError localzone()
+    end
+end

--- a/test/timezones/types.jl
+++ b/test/timezones/types.jl
@@ -13,12 +13,25 @@ import Base.Dates: Second, UTM
 @test FixedTimeZone("+01:23:45") == FixedTimeZone("UTC+01:23:45", 5025)
 @test FixedTimeZone("-01:23:45") == FixedTimeZone("UTC-01:23:45", -5025)
 @test FixedTimeZone("99:99:99") == FixedTimeZone("UTC+99:99:99", 362439)
+@test FixedTimeZone("UTC") == FixedTimeZone("UTC", 0)
+@test FixedTimeZone("UTC+00") == FixedTimeZone("UTC", 0)
+@test FixedTimeZone("UTC+1") == FixedTimeZone("UTC+01:00", 3600)
+@test FixedTimeZone("UTC-1") == FixedTimeZone("UTC-01:00", -3600)
+@test FixedTimeZone("UTC+01") == FixedTimeZone("UTC+01:00", 3600)
+@test FixedTimeZone("UTC-01") == FixedTimeZone("UTC-01:00", -3600)
+@test FixedTimeZone("UTC+0123") == FixedTimeZone("UTC+01:23", 4980)
+@test FixedTimeZone("UTC-0123") == FixedTimeZone("UTC-01:23", -4980)
 
+@test_throws Exception FixedTimeZone("1")
+@test_throws Exception FixedTimeZone("01")
 @test_throws Exception FixedTimeZone("123")
 @test_throws Exception FixedTimeZone("012345")
+@test_throws Exception FixedTimeZone("0123:45")
+@test_throws Exception FixedTimeZone("01:2345")
 @test_throws Exception FixedTimeZone("01:-23:45")
 @test_throws Exception FixedTimeZone("01:23:-45")
 @test_throws Exception FixedTimeZone("01:23:45:67")
+@test_throws Exception FixedTimeZone("UTC1")
 
 
 # Test exception messages


### PR DESCRIPTION
Determines the local systems TimeZone via the `localzone` function. Unfortunately code currently is not well tested due to OS specific code and a number of system calls or reading external files. We should be able to improve coverage when we can utilize some kind of method mocking.