### PR TITLE
Allow user-specified cutoffs for parsing Olson databases.

### DIFF
--- a/src/timezones/Olson.jl
+++ b/src/timezones/Olson.jl
@@ -47,7 +47,7 @@ typealias OrderedRuleDict Dict{AbstractString,Tuple{Array{Date},Array{Rule}}}
 
 # Min and max years that we create DST transition DateTimes for (inclusive)
 const MIN_YEAR = year(typemin(DateTime))  # Essentially the begining of time
-const MAX_YEAR = 2038                     # year(typemax(Int32))
+const MAX_YEAR = 2037                     # year(unix2datetime(typemax(Int32))) - 1
 
 # Helper functions/data
 const MONTHS = Dict("Jan"=>1,"Feb"=>2,"Mar"=>3,"Apr"=>4,"May"=>5,"Jun"=>6,

--- a/src/timezones/Olson.jl
+++ b/src/timezones/Olson.jl
@@ -529,5 +529,4 @@ function compile(tzdata_dir::AbstractString=TZDATA_DIR, dest_dir::AbstractString
     end
 end
 
-
 end # module

--- a/src/timezones/Olson.jl
+++ b/src/timezones/Olson.jl
@@ -249,69 +249,27 @@ function order_rules(rules::Array{Rule}; max_year::Integer=MAX_YEAR)
 
     # Note: Typically rules are orderd by "from" and "in". Unfortunately
     for rule in rules
-        # TODO: Rearchitect so that later transitions can be calculated on the
-        # fly.
-        #
-        # Presently, all transitions are calculated at compile time. Some Rules
-        # do not have ending dates (and Rules could have ending dates that were
-        # arbitrarily far in the future). Instead of running forever, this code
-        # makes the pragmatic decision to only calculate transitions up until
-        # an arbitrary cutoff date.
-        #
-        # Thus, any dates after our cutoff (in a given timezone) cannot be
-        # guaranteed to be valid unless that date is in UTC (n.b., we can't
-        # really make any guarantees about the accuracy of any date that has
-        # occurred after the creation of whatever version of the Olson DB we
-        # are compiling, but in this case we mean we can't even guarantee
-        # accuracy to the model of time that the source DB is offering). A date
-        # also cannot be guaranteed to be accurate if timezone transition/math
-        # ever placed that date after our cutoff (In practice, the last safe
-        # date is 20XX/12/31 23:59:59 in the furthest ahead timezone).
-        #
-        # Since we can't be accurate after this cutoff, it is important that we
-        # also don't imply we are being accurate after that cutoff. So we will
-        # ignore any rules starting after it, and truncate rules' to field to
-        # the cutoff as necessary.
-        start_year = get(rule.from, MIN_YEAR)
+        start_year = max(get(rule.from, MIN_YEAR), MIN_YEAR)
+        end_year = min(get(rule.to, max_year), max_year)
 
-        if start_year <= max_year
-            end_year = get(rule.to, max_year)
-
-            if end_year > max_year
-                # At present, nothing in ruleparse can produce an on rule
-                rule = Rule(
-                    rule.from,
-                    max_year,
-                    rule.month,
-                    rule.on,
-                    rule.at,
-                    rule.at_flag,
-                    rule.save,
-                    rule.letter
-                )
-
-                end_year = max_year
-            end
-
-            # Replicate the rule for each year that it is effective.
-            for rule_year in start_year:end_year
-                # Determine the rule transition day by starting at the
-                # beginning of the month and applying our "on" function
-                # until we reach the correct day.
-                date = Date(rule_year, rule.month)
-                try
-                    # The "on" function should evaluate to a day within the current month.
-                    date = tonext(rule.on, date; same=true, limit=daysinmonth(date))
-                catch e
-                    if isa(e, ArgumentError)
-                        error("Unable to find matching day in month $(year(date))/$(month(date))")
-                    else
-                        rethrow(e)
-                    end
+        # Replicate the rule for each year that it is effective.
+        for rule_year in start_year:end_year
+            # Determine the rule transition day by starting at the
+            # beginning of the month and applying our "on" function
+            # until we reach the correct day.
+            date = Date(rule_year, rule.month)
+            try
+                # The "on" function should evaluate to a day within the current month.
+                date = tonext(rule.on, date; same=true, limit=daysinmonth(date))
+            catch e
+                if isa(e, ArgumentError)
+                    error("Unable to find matching day in month $(year(date))/$(month(date))")
+                else
+                    rethrow(e)
                 end
-                push!(dates, date)
-                push!(ordered, rule)
             end
+            push!(dates, date)
+            push!(ordered, rule)
         end
     end
 

--- a/src/timezones/Olson.jl
+++ b/src/timezones/Olson.jl
@@ -243,7 +243,7 @@ Example:
     1919-09-16   2:00s   0       -
     1944-04-03   2:00s   1:00    S
 """
-function order_rules(rules::Array{Rule}; max_year::Int=year(MAXDATETIME))
+function order_rules(rules::Array{Rule}; max_year::Integer=year(MAXDATETIME))
     dates = Date[]
     ordered = Rule[]
 

--- a/src/timezones/Olson.jl
+++ b/src/timezones/Olson.jl
@@ -243,11 +243,9 @@ Example:
     1919-09-16   2:00s   0       -
     1944-04-03   2:00s   1:00    S
 """
-function order_rules(rules::Array{Rule}; maxdatetime::DateTime=MAXDATETIME)
+function order_rules(rules::Array{Rule}; max_year::Int=year(MAXDATETIME))
     dates = Date[]
     ordered = Rule[]
-
-    max_year = year(maxdatetime)
 
     # Note: Typically rules are orderd by "from" and "in". Unfortunately
     for rule in rules
@@ -272,8 +270,8 @@ function order_rules(rules::Array{Rule}; maxdatetime::DateTime=MAXDATETIME)
         #
         # Since we can't be accurate after this cutoff, it is important that we
         # also don't imply we are being accurate after that cutoff. So we will
-        # ignore any rules starting after maxdatetime, and truncate rules' to
-        # field to maxdatetime if necessary.
+        # ignore any rules starting after it, and truncate rules' to field to
+        # the cutoff as necessary.
         start_year = get(rule.from, year(MINDATETIME))
 
         if start_year <= max_year
@@ -375,7 +373,7 @@ function resolve!(zone_name::AbstractString, zoneset::ZoneDict, ruleset::RuleDic
             end
         else
             if !haskey(ordered, rule_name)
-                ordered[rule_name] = order_rules(ruleset[rule_name], maxdatetime=maxdatetime)
+                ordered[rule_name] = order_rules(ruleset[rule_name], max_year=year(maxdatetime))
             end
 
             dates, rules = ordered[rule_name]

--- a/test/timezones/Olson.jl
+++ b/test/timezones/Olson.jl
@@ -249,6 +249,13 @@ dates, ordered = order_rules([rule_a, rule_b, rule_c], max_year=1940)
 @test dates == [DateTime(1918, 9, 16), DateTime(1919, 4, 15), DateTime(1919, 9, 16)]
 @test ordered == [rule_a, rule_b, rule_a]
 
+# make sure order_rules works for both 32- and 64-bit julia
+for year in (Int32(1940), Int64(1940))
+    dates, ordered = order_rules([rule_a, rule_b, rule_c], max_year=year)
+    @test dates == [DateTime(1918, 9, 16), DateTime(1919, 4, 15), DateTime(1919, 9, 16)]
+    @test ordered == [rule_a, rule_b, rule_a]
+end
+
 # truncate rules ending after the cutoff
 rule_pre = ruleparse("1999", "only", "-", "Jun", "7", "2:00s", "0", "P" )
 rule_overlap = ruleparse("1999", "2001", "-", "Jan", "1", "0:00s", "0", "-")

--- a/test/timezones/Olson.jl
+++ b/test/timezones/Olson.jl
@@ -240,13 +240,13 @@ rule_c = ruleparse("1944", "only", "-", "Apr", "3", "2:00s", "1:00", "S")
 for rules in ([rule_a, rule_b, rule_c], [rule_c, rule_b, rule_a], [rule_a, rule_c, rule_b])
     dates, ordered = order_rules(rules)
 
-    @test dates == [DateTime(1918, 9, 16), DateTime(1919, 4, 15), DateTime(1919, 9, 16), DateTime(1944, 4, 3)]
+    @test dates == [Date(1918, 9, 16), Date(1919, 4, 15), Date(1919, 9, 16), Date(1944, 4, 3)]
     @test ordered == [rule_a, rule_b, rule_a, rule_c]
 end
 
 # ignore rules starting after the cutoff
 dates, ordered = order_rules([rule_a, rule_b, rule_c], max_year=1940)
-@test dates == [DateTime(1918, 9, 16), DateTime(1919, 4, 15), DateTime(1919, 9, 16)]
+@test dates == [Date(1918, 9, 16), Date(1919, 4, 15), Date(1919, 9, 16)]
 @test ordered == [rule_a, rule_b, rule_a]
 
 # make sure order_rules works for both 32- and 64-bit julia
@@ -266,17 +266,17 @@ truncated = ruleparse("1999", "2000", "-", "Jan", "1", "0:00s", "0", "-")
 
 dates, ordered = order_rules([rule_post, rule_endless, rule_overlap, rule_pre], max_year=2000)
 @test dates == [
-    DateTime(1993, 2, 2),
-    DateTime(1994, 2, 2),
-    DateTime(1995, 2, 2),
-    DateTime(1996, 2, 2),
-    DateTime(1997, 2, 2),
-    DateTime(1998, 2, 2),
-    DateTime(1999, 1, 1),
-    DateTime(1999, 2, 2),
-    DateTime(1999, 6, 7),
-    DateTime(2000, 1, 1),
-    DateTime(2000, 2, 2),
+    Date(1993, 2, 2),
+    Date(1994, 2, 2),
+    Date(1995, 2, 2),
+    Date(1996, 2, 2),
+    Date(1997, 2, 2),
+    Date(1998, 2, 2),
+    Date(1999, 1, 1),
+    Date(1999, 2, 2),
+    Date(1999, 6, 7),
+    Date(2000, 1, 1),
+    Date(2000, 2, 2),
 ]
 
 expected = [

--- a/test/timezones/Olson.jl
+++ b/test/timezones/Olson.jl
@@ -229,14 +229,16 @@ longyearbyen = resolve("Arctic/Longyearbyen", tzdata["europe"]...)
 mst = resolve("MST", tzdata["northamerica"]...)
 @test isa(mst, FixedTimeZone)
 
+
 # order rules
-    # Rule    Poland  1918    1919    -   Sep 16  2:00s   0       -
-    # Rule    Poland  1919    only    -   Apr 15  2:00s   1:00    S
-    # Rule    Poland  1944    only    -   Apr  3  2:00s   1:00    S
+#    Rule    Poland  1918    1919    -   Sep 16  2:00s   0       -
+#    Rule    Poland  1919    only    -   Apr 15  2:00s   1:00    S
+#    Rule    Poland  1944    only    -   Apr  3  2:00s   1:00    S
 rule_a = ruleparse("1918", "1919", "-", "Sep", "16", "2:00s", "0", "-")
 rule_b = ruleparse("1919", "only", "-", "Apr", "15", "2:00s", "1:00", "S")
 rule_c = ruleparse("1944", "only", "-", "Apr", "3", "2:00s", "1:00", "S")
 
+# Note: We could be alternatively be using `permutations` here.
 for rules in ([rule_a, rule_b, rule_c], [rule_c, rule_b, rule_a], [rule_a, rule_c, rule_b])
     dates, ordered = order_rules(rules)
 
@@ -249,20 +251,11 @@ dates, ordered = order_rules([rule_a, rule_b, rule_c], max_year=1940)
 @test dates == [Date(1918, 9, 16), Date(1919, 4, 15), Date(1919, 9, 16)]
 @test ordered == [rule_a, rule_b, rule_a]
 
-# make sure order_rules works for both 32- and 64-bit julia
-for year in (Int32(1940), Int64(1940))
-    dates, ordered = order_rules([rule_a, rule_b, rule_c], max_year=year)
-    @test dates == [DateTime(1918, 9, 16), DateTime(1919, 4, 15), DateTime(1919, 9, 16)]
-    @test ordered == [rule_a, rule_b, rule_a]
-end
-
 # truncate rules ending after the cutoff
 rule_pre = ruleparse("1999", "only", "-", "Jun", "7", "2:00s", "0", "P" )
 rule_overlap = ruleparse("1999", "2001", "-", "Jan", "1", "0:00s", "0", "-")
 rule_endless = ruleparse("1993", "max", "-", "Feb", "2", "6:00s", "0", "G")
 rule_post = ruleparse("2002", "only", "-", "Jan", "1", "0:00s", "0", "IP")
-
-truncated = ruleparse("1999", "2000", "-", "Jan", "1", "0:00s", "0", "-")
 
 dates, ordered = order_rules([rule_post, rule_endless, rule_overlap, rule_pre], max_year=2000)
 @test dates == [

--- a/test/timezones/Olson.jl
+++ b/test/timezones/Olson.jl
@@ -278,30 +278,17 @@ dates, ordered = order_rules([rule_post, rule_endless, rule_overlap, rule_pre], 
     Date(2000, 1, 1),
     Date(2000, 2, 2),
 ]
-
-expected = [
+# Equality check based on reference
+@test ordered == [
     rule_endless,
     rule_endless,
     rule_endless,
     rule_endless,
     rule_endless,
     rule_endless,
-    truncated,
+    rule_overlap,
     rule_endless,
     rule_pre,
-    truncated,
+    rule_overlap,
     rule_endless,
 ]
-
-for (o, e) in zip(ordered, expected)
-    @test get(o.from) == get(e.from)
-    @test isnull(o.to) == isnull(e.to)
-    if !isnull(o.to)
-        @test get(o.to) == get(e.to)
-    end
-    @test o.month == e.month
-    @test o.at == e.at
-    @test o.at_flag == e.at_flag
-    @test o.save == e.save
-    @test o.letter == e.letter
-end

--- a/test/timezones/Olson.jl
+++ b/test/timezones/Olson.jl
@@ -245,7 +245,7 @@ for rules in ([rule_a, rule_b, rule_c], [rule_c, rule_b, rule_a], [rule_a, rule_
 end
 
 # ignore rules starting after the cutoff
-dates, ordered = order_rules([rule_a, rule_b, rule_c], maxdatetime=DateTime(1940, 1, 1))
+dates, ordered = order_rules([rule_a, rule_b, rule_c], max_year=1940)
 @test dates == [DateTime(1918, 9, 16), DateTime(1919, 4, 15), DateTime(1919, 9, 16)]
 @test ordered == [rule_a, rule_b, rule_a]
 
@@ -257,7 +257,7 @@ rule_post = ruleparse("2002", "only", "-", "Jan", "1", "0:00s", "0", "IP")
 
 truncated = ruleparse("1999", "2000", "-", "Jan", "1", "0:00s", "0", "-")
 
-dates, ordered = order_rules([rule_post, rule_endless, rule_overlap, rule_pre], maxdatetime=DateTime(2000, 1, 1))
+dates, ordered = order_rules([rule_post, rule_endless, rule_overlap, rule_pre], max_year=2000)
 @test dates == [
     DateTime(1993, 2, 2),
     DateTime(1994, 2, 2),
@@ -271,17 +271,30 @@ dates, ordered = order_rules([rule_post, rule_endless, rule_overlap, rule_pre], 
     DateTime(2000, 1, 1),
     DateTime(2000, 2, 2),
 ]
-#  Test not quite right, equality on rules isn't defined
-# @test ordered == [
-#     rule_endless,
-#     rule_endless,
-#     rule_endless,
-#     rule_endless,
-#     rule_endless,
-#     rule_endless,
-#     truncated,
-#     rule_endless,
-#     rule_pre,
-#     truncated,
-#     rule_endless,
-# ]
+
+expected = [
+    rule_endless,
+    rule_endless,
+    rule_endless,
+    rule_endless,
+    rule_endless,
+    rule_endless,
+    truncated,
+    rule_endless,
+    rule_pre,
+    truncated,
+    rule_endless,
+]
+
+for (o, e) in zip(ordered, expected)
+    @test get(o.from) == get(e.from)
+    @test isnull(o.to) == isnull(e.to)
+    if !isnull(o.to)
+        @test get(o.to) == get(e.to)
+    end
+    @test o.month == e.month
+    @test o.at == e.at
+    @test o.at_flag == e.at_flag
+    @test o.save == e.save
+    @test o.letter == e.letter
+end


### PR DESCRIPTION
When parsing Olson files, rules without set `to` fields only have transitions calculated up until the end of 2038. This leads to an inconsistency in how transitions are calculated: rules with set `to` fields will have transitions calculated after that cutoff date (even if they start after that cutoff date).

While a better long-term fix would be to re-architect the code so that further transitions could be calculated after the fact, this PR mitigates the issue by: allowing the user to pass in their own cutoff, and by making `order_rules` handle that cutoff in a consistent manner. The cutoff is now strictly enforced and `to` fields are truncated to that date.

Rule|Old Code|This Code (with max_year=2038)
------|-------------|--------------
from <= 2038, to <= 2038|all transitions|all transitions
from <= 2038, to > 2038|all transitions|transitions before 2039, to changed to 2038
from <= 2038, to = Null|transitions before 2039|transitions before 2039
from > 2038, to > 2038|all transitions|no transitions
from > 2038, to = Null|no transitions|no transitions

These two changes ensure that timezones more accurately reflect olson data, and users working with dates far in the future can easily use this library.