### PR TITLE
Use millisecond precision with now(::TimeZone)

### DIFF
--- a/src/timezones/conversions.jl
+++ b/src/timezones/conversions.jl
@@ -14,6 +14,6 @@ doc"""
 Returns a `ZonedDateTime` corresponding to the user's system time in the specified `TimeZone`.
 """
 function now(tz::TimeZone)
-    utc = trunc(unix2datetime(time()), Second)
+    utc = unix2datetime(time())
     ZonedDateTime(utc, tz, from_utc=true)
 end

--- a/test/timezones/conversions.jl
+++ b/test/timezones/conversions.jl
@@ -17,4 +17,3 @@ dt = Dates.unix2datetime(time())  # Base.now in UTC
 zdt = now(warsaw)
 @test zdt.timezone == warsaw
 @test isapprox(map(Dates.datetime2unix, [dt, TimeZones.utc(zdt)])...)
-@test millisecond(zdt) == 0  # Base.now only includes up to seconds


### PR DESCRIPTION
The behaviour of `now(::TimeZone)` matches that of `Base.now()`. This change should only be merged if https://github.com/JuliaLang/julia/pull/14170 gets accepted into base Julia.

cc: @JobJob