### PR TITLE
WIP: Convenience constructors for ZonedDateTime

### DIFF
--- a/docs/arithmetic.md
+++ b/docs/arithmetic.md
@@ -8,7 +8,7 @@ julia> using Dates
 julia> warsaw = TimeZone("Europe/Warsaw")
 Europe/Warsaw
 
-julia> spring = ZonedDateTime(DateTime(2014,3,30), warsaw)
+julia> spring = ZonedDateTime(2014, 3, 30, warsaw)
 2014-03-30T00:00:00+01:00
 
 julia> spring + Day(1)
@@ -47,10 +47,10 @@ Julia allows for the use of powerful [adjuster functions](http://julia.readthedo
 ```julia
 julia> warsaw = TimeZone("Europe/Warsaw")
 
-julia> start = ZonedDateTime(DateTime(2014), warsaw)
+julia> start = ZonedDateTime(2014, warsaw)
 2014-01-01T00:00:00+01:00
 
-julia> stop = ZonedDateTime(DateTime(2015), warsaw)
+julia> stop = ZonedDateTime(2015, warsaw)
 2015-01-01T00:00:00+01:00
 
 julia> Dates.recur(start:Dates.Hour(1):stop) do d
@@ -71,10 +71,10 @@ Note the transition from standard time to daylight saving time (and back again).
 It is possible to define a range `start:step:stop` such that `start` and `stop` have different time zones. In this case the resulting `ZonedDateTime`s will all share a time zone with `start` but the range will stop at the instant that corresponds to `stop` in `start`'s time zone. For example:
 
 ```julia
-julia> start = ZonedDateTime(DateTime(2016, 1, 1, 12), TimeZone("UTC"))
+julia> start = ZonedDateTime(2016, 1, 1, 12, TimeZone("UTC"))
 2016-01-01T12:00:00+00:00
 
-julia> stop = ZonedDateTime(DateTime(2016, 1, 1, 18), TimeZone("Europe/Warsaw"))
+julia> stop = ZonedDateTime(2016, 1, 1, 18, TimeZone("Europe/Warsaw"))
 2016-01-01T18:00:00+01:00
 
 julia> collect(start:Dates.Hour(1):stop)

--- a/docs/conversions.md
+++ b/docs/conversions.md
@@ -3,7 +3,7 @@
 Switching an existing `ZonedDateTime` from one `TimeZone` to another can be done with the constructor `ZonedDateTime(::ZonedDateTime, ::TimeZone)`:
 
 ```julia
-julia> zdt = ZonedDateTime(DateTime(2014,1,1), TimeZone("UTC"))
+julia> zdt = ZonedDateTime(2014, 1, 1, TimeZone("UTC"))
 2014-01-01T00:00:00+00:00
 
 julia> ZonedDateTime(zdt, TimeZone("Asia/Tokyo"))

--- a/docs/types.md
+++ b/docs/types.md
@@ -21,6 +21,9 @@ To construct a `ZonedDateTime` instance you just need a `DateTime` and a `TimeZo
 ```julia
 julia> ZonedDateTime(DateTime(2014,1,1), TimeZone("Europe/Warsaw"))
 2014-01-01T00:00:00+01:00
+
+julia> ZonedDateTime(2014, 1, 1, TimeZone("Europe/Warsaw"))
+2014-01-01T00:00:00+01:00
 ```
 
 ## VariableTimeZone
@@ -82,14 +85,14 @@ julia> ZonedDateTime(dt, warsaw, false)  # use the hour which is not in daylight
 When working with dates prior to the year 1900 you may notice that the time zone offset includes minutes or even seconds. These kind of offsets are normal:
 
 ```julia
-julia> ZonedDateTime(DateTime(1879,1,1), warsaw)
+julia> ZonedDateTime(1879, 1, 1, warsaw)
 1879-01-01T00:00:00+01:24
 ```
 
 Alternatively, when using future dates past the year 2038 will result in an error:
 
 ```julia
-julia> ZonedDateTime(DateTime(2039), warsaw)
+julia> ZonedDateTime(2039, warsaw)
 ERROR: TimeZone Europe/Warsaw does not handle dates on or after 2038-03-28T01:00:00 UTC
  in call at ~/.julia/v0.4/TimeZones/src/timezones/types.jl:146
  in ZonedDateTime at ~/.julia/v0.4/TimeZones/src/timezones/types.jl:260
@@ -120,6 +123,6 @@ FixedTimeZone("FOO", -6 * 3600)  # 6 hours in seconds
 Constructing a `ZonedDateTime` works similarly to `VariableTimeZone`:
 
 ```julia
-julia> ZonedDateTime(DateTime(1960,1,1), TimeZone("UTC"))
+julia> ZonedDateTime(1960, 1, 1, TimeZone("UTC"))
 1960-01-01T00:00:00+00:00
 ```

--- a/src/TimeZones.jl
+++ b/src/TimeZones.jl
@@ -29,6 +29,7 @@ const COMPILED_DIR = joinpath(PKG_DIR, "deps", "compiled")
     const WIN_TRANSLATION_FILE = joinpath(PKG_DIR, "deps", "windows_to_posix")
 end
 
+include("timezones/utils.jl")
 include("timezones/time.jl")
 include("timezones/types.jl")
 include("timezones/accessors.jl")

--- a/src/timezones/types.jl
+++ b/src/timezones/types.jl
@@ -299,7 +299,19 @@ function ZonedDateTime(zdt::ZonedDateTime, tz::FixedTimeZone)
     return ZonedDateTime(zdt.utc_datetime, tz, tz)
 end
 
+
 # Convenience constructors
+function ZonedDateTime(y::Integer, m::Integer, d::Integer, h::Integer, mi::Integer, s::Integer, ms::Integer, tz::VariableTimeZone, amb::Union{Integer,Bool})
+    ZonedDateTime(DateTime(y,m,d,h,mi,s,ms), tz, amb)
+end
+
+ZonedDateTime(y::Integer, m::Integer, d::Integer, h::Integer, mi::Integer, s::Integer, tz::VariableTimeZone, amb::Union{Integer,Bool}) = ZonedDateTime(y,m,d,h,mi,s,0,tz,amb)
+ZonedDateTime(y::Integer, m::Integer, d::Integer, h::Integer, mi::Integer, tz::VariableTimeZone, amb::Union{Integer,Bool}) = ZonedDateTime(y,m,d,h,mi,0,0,tz,amb)
+ZonedDateTime(y::Integer, m::Integer, d::Integer, h::Integer, tz::VariableTimeZone, amb::Union{Integer,Bool}) = ZonedDateTime(y,m,d,h,0,0,0,tz,amb)
+ZonedDateTime(y::Integer, m::Integer, d::Integer, tz::VariableTimeZone, amb::Union{Integer,Bool}) = ZonedDateTime(y,m,d,0,0,0,0,tz,amb)
+ZonedDateTime(y::Integer, m::Integer, tz::VariableTimeZone, amb::Union{Integer,Bool}) = ZonedDateTime(y,m,1,0,0,0,0,tz,amb)
+ZonedDateTime(y::Integer, tz::VariableTimeZone, amb::Union{Integer,Bool}) = ZonedDateTime(y,1,1,0,0,0,0,tz,amb)
+
 function ZonedDateTime(y::Integer, m::Integer, d::Integer, h::Integer, mi::Integer, s::Integer, ms::Integer, tz::TimeZone)
     ZonedDateTime(DateTime(y,m,d,h,mi,s,ms), tz)
 end

--- a/src/timezones/types.jl
+++ b/src/timezones/types.jl
@@ -301,27 +301,13 @@ end
 
 
 # Convenience constructors
-function ZonedDateTime(y::Integer, m::Integer, d::Integer, h::Integer, mi::Integer, s::Integer, ms::Integer, tz::VariableTimeZone, amb::Union{Integer,Bool})
+@optional function ZonedDateTime(y::Integer, m::Integer=1, d::Integer=1, h::Integer=0, mi::Integer=0, s::Integer=0, ms::Integer=0, tz::VariableTimeZone, amb::Union{Integer,Bool})
     ZonedDateTime(DateTime(y,m,d,h,mi,s,ms), tz, amb)
 end
 
-ZonedDateTime(y::Integer, m::Integer, d::Integer, h::Integer, mi::Integer, s::Integer, tz::VariableTimeZone, amb::Union{Integer,Bool}) = ZonedDateTime(y,m,d,h,mi,s,0,tz,amb)
-ZonedDateTime(y::Integer, m::Integer, d::Integer, h::Integer, mi::Integer, tz::VariableTimeZone, amb::Union{Integer,Bool}) = ZonedDateTime(y,m,d,h,mi,0,0,tz,amb)
-ZonedDateTime(y::Integer, m::Integer, d::Integer, h::Integer, tz::VariableTimeZone, amb::Union{Integer,Bool}) = ZonedDateTime(y,m,d,h,0,0,0,tz,amb)
-ZonedDateTime(y::Integer, m::Integer, d::Integer, tz::VariableTimeZone, amb::Union{Integer,Bool}) = ZonedDateTime(y,m,d,0,0,0,0,tz,amb)
-ZonedDateTime(y::Integer, m::Integer, tz::VariableTimeZone, amb::Union{Integer,Bool}) = ZonedDateTime(y,m,1,0,0,0,0,tz,amb)
-ZonedDateTime(y::Integer, tz::VariableTimeZone, amb::Union{Integer,Bool}) = ZonedDateTime(y,1,1,0,0,0,0,tz,amb)
-
-function ZonedDateTime(y::Integer, m::Integer, d::Integer, h::Integer, mi::Integer, s::Integer, ms::Integer, tz::TimeZone)
+@optional function ZonedDateTime(y::Integer, m::Integer=1, d::Integer=1, h::Integer=0, mi::Integer=0, s::Integer=0, ms::Integer=0, tz::TimeZone)
     ZonedDateTime(DateTime(y,m,d,h,mi,s,ms), tz)
 end
-
-ZonedDateTime(y::Integer, m::Integer, d::Integer, h::Integer, mi::Integer, s::Integer, tz::TimeZone) = ZonedDateTime(y,m,d,h,mi,s,0,tz)
-ZonedDateTime(y::Integer, m::Integer, d::Integer, h::Integer, mi::Integer, tz::TimeZone) = ZonedDateTime(y,m,d,h,mi,0,0,tz)
-ZonedDateTime(y::Integer, m::Integer, d::Integer, h::Integer, tz::TimeZone) = ZonedDateTime(y,m,d,h,0,0,0,tz)
-ZonedDateTime(y::Integer, m::Integer, d::Integer, tz::TimeZone) = ZonedDateTime(y,m,d,0,0,0,0,tz)
-ZonedDateTime(y::Integer, m::Integer, tz::TimeZone) = ZonedDateTime(y,m,1,0,0,0,0,tz)
-ZonedDateTime(y::Integer, tz::TimeZone) = ZonedDateTime(y,1,1,0,0,0,0,tz)
 
 
 function ZonedDateTime(parts::Union{Period,TimeZone}...)

--- a/src/timezones/types.jl
+++ b/src/timezones/types.jl
@@ -299,6 +299,19 @@ function ZonedDateTime(zdt::ZonedDateTime, tz::FixedTimeZone)
     return ZonedDateTime(zdt.utc_datetime, tz, tz)
 end
 
+# Convenience constructors
+function ZonedDateTime(y::Integer, m::Integer, d::Integer, h::Integer, mi::Integer, s::Integer, ms::Integer, tz::TimeZone)
+    ZonedDateTime(DateTime(y,m,d,h,mi,s,ms), tz)
+end
+
+ZonedDateTime(y::Integer, m::Integer, d::Integer, h::Integer, mi::Integer, s::Integer, tz::TimeZone) = ZonedDateTime(y,m,d,h,mi,s,0,tz)
+ZonedDateTime(y::Integer, m::Integer, d::Integer, h::Integer, mi::Integer, tz::TimeZone) = ZonedDateTime(y,m,d,h,mi,0,0,tz)
+ZonedDateTime(y::Integer, m::Integer, d::Integer, h::Integer, tz::TimeZone) = ZonedDateTime(y,m,d,h,0,0,0,tz)
+ZonedDateTime(y::Integer, m::Integer, d::Integer, tz::TimeZone) = ZonedDateTime(y,m,d,0,0,0,0,tz)
+ZonedDateTime(y::Integer, m::Integer, tz::TimeZone) = ZonedDateTime(y,m,1,0,0,0,0,tz)
+ZonedDateTime(y::Integer, tz::TimeZone) = ZonedDateTime(y,1,1,0,0,0,0,tz)
+
+
 function ZonedDateTime(parts::Union{Period,TimeZone}...)
     periods = Period[]
     timezone = Nullable{TimeZone}()

--- a/src/timezones/utils.jl
+++ b/src/timezones/utils.jl
@@ -1,0 +1,90 @@
+"""
+    @optional(expr)
+
+Creates multiple method signatures to allow optional arguments before required arguments.
+For example:
+
+    f(a=1, b=2, c) = ...
+
+becomes:
+
+    f(a, b, c) = ...
+    f(a=1, c) = f(a, 2, c)
+    f(c) = f(1, 2, c)
+"""
+macro optional(ex)
+    esc(Expr(:block, optional(ex)...))
+end
+
+function optional(ex::Expr)
+    funcs = Expr[]
+    if ex.head == :function || ex.head == :(=)
+        sig, body = ex.args
+    else
+        throw(ArgumentError("Expected expression to be a function"))
+    end
+
+    # Determine the optional arguments that occur prior to the last required argument
+    dynamic = Int[]
+    last_required = 0
+    for (i, arg) in enumerate(sig.args)
+        if isa(arg, Expr) && arg.head == :kw
+            push!(dynamic, i)
+        end
+
+        if isa(arg, Symbol) || arg.head == :(::)
+            last_required = i
+        end
+    end
+    dynamic = filter(i -> i < last_required, dynamic)
+
+    # Return early if we don't have to generate additional methods
+    isempty(dynamic) && return Expr[ex]
+
+    # Generate a new signature which converts the dynamic arguments to required arguments
+    default = Array{Any}(length(dynamic))
+    new_sig = Array{Any}(length(sig.args))
+    for (i, arg) in enumerate(sig.args)
+        if i in dynamic
+            new_sig[i] = arg.args[1]
+            default[findin(dynamic,i)] = arg.args[2]
+        else
+            new_sig[i] = arg
+        end
+    end
+
+    # Generate the primary function
+    push!(funcs, Expr(ex.head, Expr(:call, new_sig...), body))
+
+    # Generate the
+    func_call = copy(sig)
+    for (i, argument) in enumerate(func_call.args)
+        isa(argument, Expr) || continue
+
+        if argument.head == :parameters
+            for keyword in argument.args
+                keyword.args[2] = keyword.args[1]
+            end
+        elseif argument.head == :(::)
+            func_call.args[i] = argument.args[1]
+        elseif argument.head == :kw
+            if isa(argument.args[1], Symbol)
+                func_call.args[i] = argument.args[1]
+            else
+                func_call.args[i] = argument.args[1].args[1]
+            end
+        end
+    end
+
+    # Generate additional methods which call the primary function
+    while !isempty(dynamic)
+        i = pop!(dynamic)
+
+        deleteat!(new_sig, i)
+        func_call.args[i] = pop!(default)
+
+        push!(funcs, Expr(:(=), Expr(:call, new_sig...), Expr(:block, copy(func_call))))
+    end
+
+    return funcs
+end

--- a/src/timezones/utils.jl
+++ b/src/timezones/utils.jl
@@ -46,8 +46,9 @@ function optional(ex::Expr)
     new_sig = Array{Any}(length(sig.args))
     for (i, arg) in enumerate(sig.args)
         if i in dynamic
-            new_sig[i] = arg.args[1]
-            default[findin(dynamic,i)] = arg.args[2]
+            name, value = arg.args
+            new_sig[i] = name
+            default[findin(dynamic,i)] = value
         else
             new_sig[i] = arg
         end

--- a/src/timezones/utils.jl
+++ b/src/timezones/utils.jl
@@ -9,7 +9,7 @@ For example:
 becomes:
 
     f(a, b, c) = ...
-    f(a=1, c) = f(a, 2, c)
+    f(a, c) = f(a, 2, c)
     f(c) = f(1, 2, c)
 """
 macro optional(ex)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,7 @@ for name in ("australasia", "europe", "northamerica")
     tzdata[name] = tzparse(joinpath(TZDATA_DIR, name))
 end
 
+include("timezones/utils.jl")
 include("timezones/time.jl")
 include("timezones/Olson.jl")
 include("timezones/types.jl")

--- a/test/timezones/types.jl
+++ b/test/timezones/types.jl
@@ -331,4 +331,23 @@ zdt = ZonedDateTime(DateTime(2200, 1, 1), perth, from_utc=true)
 digits = [2010, 1, 2, 3, 4, 5, 6]
 for i in eachindex(digits)
     @test ZonedDateTime(digits[1:i]..., warsaw) == ZonedDateTime(DateTime(digits[1:i]...), warsaw)
+    @test ZonedDateTime(digits[1:i]..., utc) == ZonedDateTime(DateTime(digits[1:i]...), utc)
+end
+
+# Convenience constructor dealing with ambiguous time
+digits = [1916, 10, 1, 0, 2, 3, 4]  # Fall DST transition in Europe/Warsaw
+for i in eachindex(digits)
+    expected = [
+        ZonedDateTime(DateTime(digits[1:i]...), warsaw, 1)
+        ZonedDateTime(DateTime(digits[1:i]...), warsaw, 2)
+    ]
+
+    if i > 1
+        @test_throws AmbiguousTimeError ZonedDateTime(digits[1:i]..., warsaw)
+    end
+
+    @test ZonedDateTime(digits[1:i]..., warsaw, 1) == expected[1]
+    @test ZonedDateTime(digits[1:i]..., warsaw, 2) == expected[2]
+    @test ZonedDateTime(digits[1:i]..., warsaw, true) == expected[1]
+    @test ZonedDateTime(digits[1:i]..., warsaw, false) == expected[2]
 end

--- a/test/timezones/types.jl
+++ b/test/timezones/types.jl
@@ -325,3 +325,10 @@ zdt = ZonedDateTime(DateTime(2038, 3, 28), warsaw, from_utc=true)
 # eg. Asia/Hong_Kong, Pacific/Honolulu, Australia/Perth
 perth = resolve("Australia/Perth", tzdata["australasia"]...)
 zdt = ZonedDateTime(DateTime(2200, 1, 1), perth, from_utc=true)
+
+
+# Convenience constructors for making a DateTime on-the-fly
+digits = [2010, 1, 2, 3, 4, 5, 6]
+for i in eachindex(digits)
+    @test ZonedDateTime(digits[1:i]..., warsaw) == ZonedDateTime(DateTime(digits[1:i]...), warsaw)
+end

--- a/test/timezones/utils.jl
+++ b/test/timezones/utils.jl
@@ -1,0 +1,64 @@
+import TimeZones: optional
+
+function strip(ex::Expr)
+    args = []
+    for arg in ex.args
+        if isa(arg, Expr)
+            arg = strip(arg)
+        end
+
+        if !isa(arg, LineNumberNode)
+            push!(args, arg)
+        end
+    end
+
+    return Expr(ex.head, args...)
+end
+
+Base.isequal(a::Array{Expr}, b::Array{Expr}) = map(strip, a) == map(strip, b)
+
+
+
+# We can include comments in our comparison here since the expressions are on the same line
+@test optional(:(foo(a, b, c=3; d=4) = nothing)) == [:(foo(a, b, c=3; d=4) = nothing)]
+
+@test isequal(
+    optional(
+        :(foo(a, b=2, c) = nothing)
+    ),
+    [
+        :(foo(a, b, c) = nothing),
+        :(foo(a, c) = foo(a, 2, c)),
+    ],
+)
+
+@test isequal(
+    optional(
+        :(foo(a, b=2, c=3, d, e=5; f=6) = nothing)
+    ),
+    [
+        :(foo(a, b, c, d, e=5; f=6) = nothing),
+        :(foo(a, b, d, e=5; f=6) = foo(a, b, 3, d, e; f=f)),
+        :(foo(a, d, e=5; f=6) = foo(a, 2, 3, d, e; f=f)),
+    ],
+)
+
+typealias I Integer
+@test isequal(
+    optional(
+        :(function ZonedDateTime(y::I, m::I=1, d::I=1, h::I=0, mi::I=0, s::I=0, ms::I=0, tz::TimeZone)
+            ZonedDateTime(DateTime(y,m,d,h,mi,s,ms), tz)
+        end)
+    ),
+    [
+        :(function ZonedDateTime(y::I,m::I,d::I,h::I,mi::I,s::I,ms::I,tz::TimeZone)
+            ZonedDateTime(DateTime(y,m,d,h,mi,s,ms), tz)
+        end),
+        :(ZonedDateTime(y::I,m::I,d::I,h::I,mi::I,s::I,tz::TimeZone) = ZonedDateTime(y,m,d,h,mi,s,0,tz)),
+        :(ZonedDateTime(y::I,m::I,d::I,h::I,mi::I,tz::TimeZone) = ZonedDateTime(y,m,d,h,mi,0,0,tz)),
+        :(ZonedDateTime(y::I,m::I,d::I,h::I,tz::TimeZone) = ZonedDateTime(y,m,d,h,0,0,0,tz)),
+        :(ZonedDateTime(y::I,m::I,d::I,tz::TimeZone) = ZonedDateTime(y,m,d,0,0,0,0,tz)),
+        :(ZonedDateTime(y::I,m::I,tz::TimeZone) = ZonedDateTime(y,m,1,0,0,0,0,tz)),
+        :(ZonedDateTime(y::I,tz::TimeZone) = ZonedDateTime(y,1,1,0,0,0,0,tz)),
+    ],
+)

--- a/test/timezones/utils.jl
+++ b/test/timezones/utils.jl
@@ -62,3 +62,14 @@ typealias I Integer
         :(ZonedDateTime(y::I,tz::TimeZone) = ZonedDateTime(y,1,1,0,0,0,0,tz)),
     ],
 )
+
+# Currently demonstrates an issue when the type given doesn't match value
+# @test isequal(
+#     TimeZones.flexible(
+#         :(f(a::Float64=1, b) = nothing)
+#     ),
+#     [
+#         :(f(a::Float64, b) = nothing),
+#         :(f(b) = f(1.0, b)),
+#     ]
+# )


### PR DESCRIPTION
There has been some interest in creating a `ZonedDateTime` without first creating a `DateTime` object. This pull request implements the requested functionality.

I'll note we could also have additional constructors that take in a `AbstractString` timezone name rather than having to create a `TimeZone` object but this leads into issues with knowing if the `TimeZone` is a `VariableTimeZone` or not and whether we need to have the `is_dst` argument supplied.